### PR TITLE
Add unquoted, quoted and interpolated values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: php
+php:
+- '5.6'
+
+script:
+- ./tests/dotenv-test.sh

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
+[![Build Status](https://travis-ci.org/dinhoabreu/dotenv-shell.svg?branch=improve_value)](https://travis-ci.org/dinhoabreu/dotenv-shell)
+
 # dotenv-shell
+
 Use Dotenv in everything
 
 ## Install
 
 ```
-curl https://raw.githubusercontent.com/madcoda/dotenv-shell/master/dotenv.sh > /usr/local/bin/dotenv
+curl https://raw.githubusercontent.com/dinhoabreu/dotenv-shell/improve_value/dotenv.sh > /usr/local/bin/dotenv
 chmod +x /usr/local/bin/dotenv
 ```
 
 ## Usage
-```
+
+```sh
+# Run command
 dotenv run_my_command param1 param2
+# or Export to current shell
+. dotenv
 ```

--- a/dotenv.sh
+++ b/dotenv.sh
@@ -1,13 +1,36 @@
 #!/bin/sh
 set -e
 
+is_comment() {
+	case "$1" in
+	\#*)
+		if [ "$VERBOSE" = 1 ]; then
+			echo "Skip: $1" >&2
+		fi
+		return 0
+		;;
+	esac
+	return 1
+}
+
+export_envs() {
+	while IFS='=' read -r key temp; do
+		if is_comment "$key"; then
+			continue
+		fi
+		value=$(eval echo "$temp")
+		eval export "$key='$value'";
+	done < .env
+}
 
 # inject .env configs into the shell
 if [ -f .env ]; then
-	export $(cat .env | grep -v ^# | xargs)
+	export_envs
 else
-	echo ".env file not found"
+	echo '.env file not found' >&2
 fi
 
 # then run whatever commands you like
-exec "$@"
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,9 @@
+# Comment 1
+TEST_UNQUOTED=a=1 b=2 c=3
+# Comment 2
+TEST_SINGLE_QUOTED='1 2 3 4'
+# Comment 3
+TEST_DOUBLE_QUOTED="1 2 3 4"
+# Comment 4
+TEST_INTERPOLATION="$TEST_UNQUOTED d=4"
+# Comment 5

--- a/tests/dotenv-test.sh
+++ b/tests/dotenv-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+
+main() {
+
+    cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+
+    # shellcheck disable=SC1091
+    source ../dotenv.sh
+    assert_equal "$TEST_UNQUOTED" 'a=1 b=2 c=3' 'Testing unquoted'
+    assert_equal "$TEST_SINGLE_QUOTED" '1 2 3 4' 'Testing single quoted'
+    assert_equal "$TEST_DOUBLE_QUOTED" '1 2 3 4' 'Testing double quoted'
+    assert_equal "$TEST_INTERPOLATION" 'a=1 b=2 c=3 d=4' 'Testing interpolation'
+}
+
+assert_equal() {
+
+    local value=$1 expected=$2 label=$3
+
+    if [ "$value" == "$expected" ]; then
+        echo "$label: ok"
+        return 0
+    fi
+    echo "$label: fail [expected: '$expected' value: '$value']"
+    return 1
+}
+
+main "$@"


### PR DESCRIPTION
Hi @madcoda,

I made some changes to support:

- Values unquoted (useful when work with [docker-compose](https://docs.docker.com/compose/env-file/)), single quoted and double quoted.
- Interpolated variables like `MY_VAR=/opt/my_project/bin:$PATH`
- Tests and CI

Example `.env` supported:

```bash
TEST_UNQUOTED=a=1 b=2 c=3
TEST_SINGLE_QUOTED='1 2 3 4'
TEST_DOUBLE_QUOTED="1 2 3 4"
TEST_INTERPOLATION=$TEST_SPACES_1 d=4
```

Thank you