### PR TITLE
Support blank lines, ignore existing ENV variables, handle missing newline

### DIFF
--- a/dotenv.sh
+++ b/dotenv.sh
@@ -13,13 +13,36 @@ is_comment() {
 	return 1
 }
 
+is_blank() {
+	case "$1" in
+	'')
+		if [ "$VERBOSE" = 1 ]; then
+			echo "Skip: $1" >&2
+		fi
+		return 0
+		;;
+	esac
+	return 1
+}
+
 export_envs() {
-	while IFS='=' read -r key temp; do
+	while IFS='=' read -r key temp || [ -n "$key" ]; do
 		if is_comment "$key"; then
 			continue
 		fi
-		value=$(eval echo "$temp")
-		eval export "$key='$value'";
+		if is_blank "$key"; then
+			continue
+		fi
+		
+		eval val=\""\$$key"\"
+	    if [ -z $val ]; then
+			value=$(eval echo "$temp")
+			eval export "$key='$value'";
+	    else
+			if [ "$VERBOSE" = 1 ]; then
+				echo "Existing: $key=$val" >&2
+			fi       
+	    fi
 	done < .env
 }
 

--- a/tests/.env
+++ b/tests/.env
@@ -7,3 +7,9 @@ TEST_DOUBLE_QUOTED="1 2 3 4"
 # Comment 4
 TEST_INTERPOLATION="$TEST_UNQUOTED d=4"
 # Comment 5
+# Test blank lines are ok
+
+# Test preservation of existing variables
+TEST_EXISTING="unexpected"
+# Test that the last variable is parsed despite no trailing new line
+TEST_NO_NEWLINE="still there"

--- a/tests/dotenv-test.sh
+++ b/tests/dotenv-test.sh
@@ -8,6 +8,7 @@ main() {
     # shellcheck disable=SC1091
     export TEST_EXISTING="expected"
     source ../dotenv.sh
+    echo "Testing blank line parsing: ok" # i.e. didn't crash
     assert_equal "$TEST_UNQUOTED" 'a=1 b=2 c=3' 'Testing unquoted'
     assert_equal "$TEST_SINGLE_QUOTED" '1 2 3 4' 'Testing single quoted'
     assert_equal "$TEST_DOUBLE_QUOTED" '1 2 3 4' 'Testing double quoted'

--- a/tests/dotenv-test.sh
+++ b/tests/dotenv-test.sh
@@ -4,13 +4,16 @@
 main() {
 
     cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
+    
     # shellcheck disable=SC1091
+    export TEST_EXISTING="expected"
     source ../dotenv.sh
     assert_equal "$TEST_UNQUOTED" 'a=1 b=2 c=3' 'Testing unquoted'
     assert_equal "$TEST_SINGLE_QUOTED" '1 2 3 4' 'Testing single quoted'
     assert_equal "$TEST_DOUBLE_QUOTED" '1 2 3 4' 'Testing double quoted'
     assert_equal "$TEST_INTERPOLATION" 'a=1 b=2 c=3 d=4' 'Testing interpolation'
+    assert_equal "$TEST_EXISTING" 'expected' 'Testing preservation of existing variables'
+    assert_equal "$TEST_NO_NEWLINE" 'still there' 'Testing parsing of last line'
 }
 
 assert_equal() {


### PR DESCRIPTION
Added tests and implemented support for the following:

- Ignore existing ENV variables like other dotenv implementations [npm](https://www.npmjs.com/package/dotenv) [python](https://pypi.python.org/pypi/python-dotenv) [ruby](https://github.com/bkeepers/dotenv) etc etc
- Support blank lines in the .env file
- Handle missing newline at the end, because it happens