### PR TITLE
Allow envvar overwrite

### DIFF
--- a/dotenv.sh
+++ b/dotenv.sh
@@ -54,14 +54,20 @@ export_envs() {
 			continue
 		fi
 
-		if is_set "$key"; then
-			log_verbose "Existing: $key=$val"
-		else
-			value=$(eval echo "$temp")
-			eval export "$key='$value'";
-		fi
+        value=$(eval echo "$temp")
+        eval export "$key='$value'";
 	done < $1
 }
+
+# inject any defaults into the shell
+if is_set "DOTENV_DEFAULT"; then
+	log_verbose "Setting defaults via $DOTENV_DEFAULT"
+	if [ -f "$DOTENV_DEFAULT" ]; then
+		export_envs "$DOTENV_DEFAULT"
+	else
+		echo '$DOTENV_DEFAULT file not found'
+	fi
+fi
 
 if is_set "DOTENV_FILE"; then
 	log_verbose "Reading from $DOTENV_FILE"
@@ -76,15 +82,6 @@ else
 	echo "$DOTENV_FILE file not found"
 fi
 
-# inject any defaults into the shell
-if is_set "DOTENV_DEFAULT"; then
-	log_verbose "Setting defaults via $DOTENV_DEFAULT"
-	if [ -f "$DOTENV_DEFAULT" ]; then
-		export_envs "$DOTENV_DEFAULT"
-	else
-		echo '$DOTENV_DEFAULT file not found'
-	fi
-fi
 
 # then run whatever commands you like
 if [ $# -gt 0 ]; then

--- a/tests/.env
+++ b/tests/.env
@@ -10,7 +10,7 @@ TEST_INTERPOLATION="$TEST_UNQUOTED d=4"
 # Test blank lines are ok
 
 # Test preservation of existing variables
-TEST_EXISTING="unexpected"
+TEST_EXISTING="new-value"
 # Test secrets override defaults
 TEST_DOTENV_OVERRIDES_DEFAULT="expected"
 # Test that the last variable is parsed despite no trailing new line

--- a/tests/dotenv-test.sh
+++ b/tests/dotenv-test.sh
@@ -13,7 +13,7 @@ main() {
     assert_equal "$TEST_SINGLE_QUOTED" '1 2 3 4' 'Testing single quoted'
     assert_equal "$TEST_DOUBLE_QUOTED" '1 2 3 4' 'Testing double quoted'
     assert_equal "$TEST_INTERPOLATION" 'a=1 b=2 c=3 d=4' 'Testing interpolation'
-    assert_equal "$TEST_EXISTING" 'expected' 'Testing preservation of existing variables'
+    assert_equal "$TEST_EXISTING" 'new-value' 'Testing overwrite of existing variables'
     assert_equal "$TEST_NO_NEWLINE" 'still there' 'Testing parsing of last line'
     assert_equal "$TEST_DEFAULT_ENVFILE" 'expected' 'Test loading variables from default.env file'
     assert_equal "$TEST_DOTENV_OVERRIDES_DEFAULT" 'expected' 'Test .env variables override variables from default.env file'


### PR DESCRIPTION
Sometimes the user would like to overwrite a environment variable that
exists on the user configuration, like the HOME, GOPATH or something
else.

This PR will load the DOTENV_DEFAULT first and after that will load the
DOTENV_FILE.