### PR TITLE
Support special characters in environment variables

### DIFF
--- a/dotenv.sh
+++ b/dotenv.sh
@@ -54,7 +54,12 @@ export_envs() {
 			continue
 		fi
 
-        value=$(eval echo "$temp")
+		# Strip any existing quotes
+		temp="${temp%[\'\"]}";
+		temp="${temp#[\'\"]}";
+		# Add new double quotes for interpolation
+		value=$(eval echo "\"$temp\"");
+		
         eval export "$key='$value'";
 	done < $1
 }

--- a/tests/.env
+++ b/tests/.env
@@ -13,5 +13,7 @@ TEST_INTERPOLATION="$TEST_UNQUOTED d=4"
 TEST_EXISTING="new-value"
 # Test secrets override defaults
 TEST_DOTENV_OVERRIDES_DEFAULT="expected"
+# Test special characters are escaped
+TEST_SPECIAL_CHARACTER=special(character
 # Test that the last variable is parsed despite no trailing new line
 TEST_NO_NEWLINE="still there"

--- a/tests/dotenv-test.sh
+++ b/tests/dotenv-test.sh
@@ -17,6 +17,7 @@ main() {
     assert_equal "$TEST_NO_NEWLINE" 'still there' 'Testing parsing of last line'
     assert_equal "$TEST_DEFAULT_ENVFILE" 'expected' 'Test loading variables from default.env file'
     assert_equal "$TEST_DOTENV_OVERRIDES_DEFAULT" 'expected' 'Test .env variables override variables from default.env file'
+    assert_equal "$TEST_SPECIAL_CHARACTER" 'special(character' 'Testing special characters'
 
     TEST_NO_ENVFILE=`DOTENV_FILE=nonexistent.env ../dotenv.sh`
     assert_equal "$TEST_NO_ENVFILE" "nonexistent.env file not found" 'Test error message from missing .env file'


### PR DESCRIPTION
Variables like `EXAMPLE=special(character` were getting interpreted by eval. These have been wrapped in double quotes to prevent this from happening.

This PR was developed from this issue:
https://github.com/c-py/action-dotenv-to-setenv/issues/3